### PR TITLE
Pin package versions

### DIFF
--- a/LFS171x/fabric-material/tuna-app/package.json
+++ b/LFS171x/fabric-material/tuna-app/package.json
@@ -4,13 +4,13 @@
     "description": "Hyperledger Fabric MOOC Sample Application",
     "main": "server.js",
     "dependencies": {
-        "fabric-ca-client": "^1.0.2",
-        "fabric-client": "^1.0.2",
-        "grpc": "^1.6.0",
+        "fabric-ca-client": "1.0.2",
+        "fabric-client": "1.0.2",
+        "grpc": "1.6.0",
         "express": "latest",
         "body-parser": "latest",
         "ejs": "latest",
-        "angular": "^1.4.3"
+        "angular": "1.4.3"
     },
     "license": "Apache-2.0",
     "keywords": [


### PR DESCRIPTION
`fabric-client` seems to have removed Client.newEventHub in later versions. That caused the following error for me when trying to add tuna or change holders in the client app:

    TypeError: fabric_client.newEventHub is not a function

Pinning it (and some dependencies) solved the issue for me.